### PR TITLE
Column and Row Specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,50 @@
 [![Build Status](https://travis-ci.org/python-excel/xlrd.svg?branch=master)](https://travis-ci.org/python-excel/xlrd)
 [![Coverage Status](https://coveralls.io/repos/github/python-excel/xlrd/badge.svg?branch=master)](https://coveralls.io/github/python-excel/xlrd?branch=master)
 [![Documentation Status](https://readthedocs.org/projects/xlrd/badge/?version=latest)](http://xlrd.readthedocs.io/en/latest/?badge=latest)
-[![PyPI version](https://badge.fury.io/py/xlrd.svg)](https://badge.fury.io/py/xlrd)
+[![PyPI version](https://badge.fury.io/py/xlrdinc.svg)](https://badge.fury.io/py/xlrdinc)
 
 # Fork of PyPI package `xlrd`
 
 Name of new package: `xlrdinc`
 
 We are currently using a lot of Python-UNO stuff, but have found the original libraries a little unmaintained (or at least slow in responding to bug reports). We do ask that you file issues directly on this repo instead of the original repo we forked from; we have no control over that original repo, and don't foresee timely response from the maintainers of that repo.
+
+# Testing
+
+To encourage contributions, we clearly state for your convenience here how to test the contributions you make.
+
+## Quick Test --- Single Python Version
+
+### Virtual Environment
+
+Ensure your `virtualenv` package is up-to-date:
+
+    pip install --upgrade virtualenv
+
+Create a virtual environment via:
+
+    `virtualenv -p python3 <env-folder>`
+
+We suggest `~/xlrdinc-env` for `<env-folder>`. Test your contribution with the latest Python 3; this close to year 2020, we encourage you to save the effort in testing against Python 2. Let us help you test against Python 2.
+
+Activate your environment via:
+
+    `source <env-folder>/bin/activate`.
+
+### Single Test
+
+At the top-level folder of this project, this command executes a single test `test_colx_to_int` in test case `TestSheet` residing in module `test.test_sheet`. In Python speak, that module is the file `tests/test_sheet.py`.
+
+    python3 -m unittest tests.test_sheet.TestSheet.test_colx_to_int
+
+## All Tests
+
+At the top-level folder of this project, this command executes all tests discovered.
+
+    python3 -m unittest
+    # Equivalent to `python3 -m unittest discover'
+
+For [test discovery](https://docs.python.org/3/library/unittest.html#unittest-test-discovery) to work, your tests must conform to certain conventions. These conventions can be easily gleaned from numerous examples in this project's test cases.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,16 @@ Name of new package: `xlrdinc`
 
 We are currently using a lot of Python-UNO stuff, but have found the original libraries a little unmaintained (or at least slow in responding to bug reports). We do ask that you file issues directly on this repo instead of the original repo we forked from; we have no control over that original repo, and don't foresee timely response from the maintainers of that repo.
 
+**Merging `.xlsx` and `.xls` Handling.** At some point soon, we will merge `.xlsx` handling packages (`openpyxl`, `xlsxwriter`, etc) into this project. We will ask the community for a new project name *after* that merge has been achieved.
+
+# Table of Contents
+
+- [Testing](#testing)
+  - [Quick Test --- Single Python Version](#quick-test-----single-python-version)
+- [Original README](#original-readme)
+- [Help Us In Open-Source?](#help-us-in-open-source)
+- [Our Background, Our Gaps](#our-background-our-gaps)
+
 # Testing
 
 To encourage contributions, we clearly state for your convenience here how to test the contributions you make.
@@ -23,13 +33,13 @@ Ensure your `virtualenv` package is up-to-date:
 
 Create a virtual environment via:
 
-    `virtualenv -p python3 <env-folder>`
+    virtualenv -p python3 <env-folder>
 
 We suggest `~/xlrdinc-env` for `<env-folder>`. Test your contribution with the latest Python 3; this close to year 2020, we encourage you to save the effort in testing against Python 2. Let us help you test against Python 2.
 
 Activate your environment via:
 
-    `source <env-folder>/bin/activate`.
+    source <env-folder>/bin/activate
 
 ### Single Test
 
@@ -37,7 +47,7 @@ At the top-level folder of this project, this command executes a single test `te
 
     python3 -m unittest tests.test_sheet.TestSheet.test_colx_to_int
 
-## All Tests
+### All Tests
 
 At the top-level folder of this project, this command executes all tests discovered.
 

--- a/tests/test_biffh.py
+++ b/tests/test_biffh.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from xlrd import biffh
+from xlrdinc import biffh
 
 if sys.version_info[0] >= 3:
     from io import StringIO

--- a/tests/test_cell.py
+++ b/tests/test_cell.py
@@ -2,8 +2,8 @@
 
 import unittest
 
-import xlrd
-from xlrd.timemachine import UNICODE_LITERAL
+import xlrdinc as xlrd
+from xlrdinc.timemachine import UNICODE_LITERAL
 
 from .base import from_this_dir
 

--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -4,7 +4,7 @@
 import sys
 from unittest import TestCase
 
-import xlrd
+import xlrdinc as xlrd
 
 from .base import from_this_dir
 

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -3,7 +3,7 @@
 
 from unittest import TestCase
 
-import xlrd
+import xlrdinc as xlrd
 
 from .base import from_this_dir
 

--- a/tests/test_missing_records.py
+++ b/tests/test_missing_records.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
-from xlrd import open_workbook
-from xlrd.biffh import XL_CELL_TEXT
+from xlrdinc import open_workbook
+from xlrdinc.biffh import XL_CELL_TEXT
 
 from .base import from_this_dir
 

--- a/tests/test_open_workbook.py
+++ b/tests/test_open_workbook.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 from unittest import TestCase
 
-from xlrd import open_workbook
+from xlrdinc import open_workbook
 
 from .base import from_this_dir
 

--- a/tests/test_sheet.py
+++ b/tests/test_sheet.py
@@ -3,8 +3,8 @@
 import types
 from unittest import TestCase
 
-import xlrd
-from xlrd.timemachine import xrange
+import xlrdinc as xlrd
+from xlrdinc.timemachine import xrange
 
 from .base import from_this_dir
 
@@ -47,6 +47,14 @@ class TestSheet(TestCase):
     def test_ncols(self):
         sheet = self.book.sheet_by_index(SHEETINDEX)
         self.assertEqual(sheet.ncols, NCOLS)
+
+    def test_colx_to_int(self):
+        sheet = self.book.sheet_by_index(SHEETINDEX)
+        Sheet = sheet.__class__
+        self.assertEqual(2, Sheet.colx_to_int('C'))
+        self.assertEqual(27, Sheet.colx_to_int('AB'))
+        self.assertEqual(15, Sheet.colx_to_int('15'))
+        self.assertEqual(16, Sheet.colx_to_int(16))
 
     def test_cell(self):
         sheet = self.book.sheet_by_index(SHEETINDEX)

--- a/tests/test_workbook.py
+++ b/tests/test_workbook.py
@@ -2,9 +2,9 @@
 
 from unittest import TestCase
 
-from xlrd import open_workbook
-from xlrd.book import Book
-from xlrd.sheet import Sheet
+from xlrdinc import open_workbook
+from xlrdinc.book import Book
+from xlrdinc.sheet import Sheet
 
 from .base import from_this_dir
 

--- a/tests/test_xldate.py
+++ b/tests/test_xldate.py
@@ -7,7 +7,7 @@
 
 import unittest
 
-from xlrd import xldate
+from xlrdinc import xldate
 
 DATEMODE = 0 # 1900-based
 

--- a/tests/test_xldate_to_datetime.py
+++ b/tests/test_xldate_to_datetime.py
@@ -6,7 +6,7 @@
 import unittest
 from datetime import datetime
 
-from xlrd import xldate
+from xlrdinc import xldate
 
 not_1904 = False
 is_1904 = True

--- a/tests/test_xlsx_comments.py
+++ b/tests/test_xlsx_comments.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from xlrd import open_workbook
+from xlrdinc import open_workbook
 
 from .base import from_this_dir
 

--- a/tests/test_xlsx_parse.py
+++ b/tests/test_xlsx_parse.py
@@ -5,7 +5,7 @@
 
 import unittest
 
-import xlrd
+import xlrdinc as xlrd
 
 from .base import from_this_dir
 

--- a/xlrdinc/sheet.py
+++ b/xlrdinc/sheet.py
@@ -400,10 +400,36 @@ class Sheet(BaseObject):
         # self._put_cell_rows_appended = 0
         # self._put_cell_cells_appended = 0
 
+    def colx_to_int(colx):
+        """Converts alpha/decimal str to int for column specifiers.
+
+        Eg. 'AB' becomes 52.
+        """
+        if isinstance(colx, str):
+            if colx.isalpha():
+                result = 0
+                factor = 1
+                for char in colx[::-1]:
+                    result += (ord(char.upper()) - 64) * factor
+                    factor *= 26
+                colx = result - 1 # zero-based index
+            elif colx.isdecimal():
+                return int(colx)
+        return colx
+
+    def rowx_to_int(rowx):
+        "Converts decimal str to int for row specifiers."
+        if isinstance(rowx, str):
+            if colx.isdecimal():
+                return int(rowx)
+        return rowx
+
     def cell(self, rowx, colx):
         """
         :class:`Cell` object in the given row and column.
         """
+        rowx = Sheet.rowx_to_int(rowx)
+        colx = Sheet.colx_to_int(colx)
         if self.formatting_info:
             xfx = self.cell_xf_index(rowx, colx)
         else:
@@ -416,6 +442,8 @@ class Sheet(BaseObject):
 
     def cell_value(self, rowx, colx):
         "Value of the cell in the given row and column."
+        rowx = Sheet.rowx_to_int(rowx)
+        colx = Sheet.colx_to_int(colx)
         return self._cell_values[rowx][colx]
 
     def cell_type(self, rowx, colx):
@@ -424,6 +452,8 @@ class Sheet(BaseObject):
 
         Refer to the documentation of the :class:`Cell` class.
         """
+        rowx = Sheet.rowx_to_int(rowx)
+        colx = Sheet.colx_to_int(colx)
         return self._cell_types[rowx][colx]
 
     def cell_xf_index(self, rowx, colx):
@@ -433,6 +463,8 @@ class Sheet(BaseObject):
 
         .. versionadded:: 0.6.1
         """
+        rowx = Sheet.rowx_to_int(rowx)
+        colx = Sheet.colx_to_int(colx)
         self.req_fmt_info()
         xfx = self._cell_xf_indexes[rowx][colx]
         if xfx > -1:
@@ -465,12 +497,14 @@ class Sheet(BaseObject):
 
         .. versionadded:: 0.7.2
         """
+        rowx = Sheet.rowx_to_int(rowx)
         return len(self._cell_values[rowx])
 
     def row(self, rowx):
         """
         Returns a sequence of the :class:`Cell` objects in the given row.
         """
+        rowx = Sheet.rowx_to_int(rowx)
         return [
             self.cell(rowx, colx)
             for colx in xrange(len(self._cell_values[rowx]))
@@ -484,6 +518,9 @@ class Sheet(BaseObject):
         """
         Returns a slice of the types of the cells in the given row.
         """
+        rowx = Sheet.rowx_to_int(rowx)
+        start_colx = Sheet.colx_to_int(start_colx)
+        end_colx = Sheet.colx_to_int(end_colx)
         if end_colx is None:
             return self._cell_types[rowx][start_colx:]
         return self._cell_types[rowx][start_colx:end_colx]
@@ -492,6 +529,9 @@ class Sheet(BaseObject):
         """
         Returns a slice of the values of the cells in the given row.
         """
+        rowx = Sheet.rowx_to_int(rowx)
+        start_colx = Sheet.colx_to_int(start_colx)
+        end_colx = Sheet.colx_to_int(end_colx)
         if end_colx is None:
             return self._cell_values[rowx][start_colx:]
         return self._cell_values[rowx][start_colx:end_colx]
@@ -500,6 +540,9 @@ class Sheet(BaseObject):
         """
         Returns a slice of the :class:`Cell` objects in the given row.
         """
+        rowx = Sheet.rowx_to_int(rowx)
+        start_colx = Sheet.colx_to_int(start_colx)
+        end_colx = Sheet.colx_to_int(end_colx)
         nc = len(self._cell_values[rowx])
         if start_colx < 0:
             start_colx += nc
@@ -518,6 +561,9 @@ class Sheet(BaseObject):
         """
         Returns a slice of the :class:`Cell` objects in the given column.
         """
+        colx = Sheet.rowx_to_int(colx)
+        start_rowx = Sheet.colx_to_int(start_rowx)
+        end_rowx = Sheet.colx_to_int(end_rowx)
         nr = self.nrows
         if start_rowx < 0:
             start_rowx += nr
@@ -536,6 +582,9 @@ class Sheet(BaseObject):
         """
         Returns a slice of the values of the cells in the given column.
         """
+        colx = Sheet.rowx_to_int(colx)
+        start_rowx = Sheet.colx_to_int(start_rowx)
+        end_rowx = Sheet.colx_to_int(end_rowx)
         nr = self.nrows
         if start_rowx < 0:
             start_rowx += nr
@@ -554,6 +603,9 @@ class Sheet(BaseObject):
         """
         Returns a slice of the types of the cells in the given column.
         """
+        colx = Sheet.rowx_to_int(colx)
+        start_rowx = Sheet.colx_to_int(start_rowx)
+        end_rowx = Sheet.colx_to_int(end_rowx)
         nr = self.nrows
         if start_rowx < 0:
             start_rowx += nr


### PR DESCRIPTION
In Excel, column specifiers are alphabets, eg `D` to mean 4th column and `AD` to mean 31st column. This PR allows that specifier format.

Also, even numeric strings (zero-based index) are allowed, in case you need to read numeric strings from a config/ini file.

Includes some refinements to README.